### PR TITLE
Refactor: Improve active_origin update robustness in setMarker

### DIFF
--- a/background.js
+++ b/background.js
@@ -362,14 +362,15 @@ async function setMarker(origin) {
   // Origin changed during the marker calculation
   if (pending_origin !== origin) return;
 
-  await chrome.bookmarks
-    .update(bookmark, {
+  try {
+    await chrome.bookmarks.update(bookmark, {
       title: marker
-    })
-    .catch((error) => {
-      console.error('Error updating bookmark:', error);
     });
-  active_origin = origin;
+    active_origin = origin; // Only set on success
+  } catch (error) {
+    console.error('Error updating bookmark:', error);
+    // active_origin remains unchanged, so a retry is possible if the origin is checked again
+  }
 }
 
 async function checkOrigin() {


### PR DESCRIPTION
In the setMarker function in background.js, the active_origin state variable is now updated only after a successful chrome.bookmarks.update() API call.

Previously, active_origin was updated regardless of the success or failure of the bookmark update. This could lead to a state where active_origin reflected an origin for which the marker was not successfully displayed on the bookmark (if the update failed). Subsequent checks for the same origin would then incorrectly assume the marker was up-to-date and not retry.

This change ensures that if updating the bookmark title fails, active_origin remains unchanged. This allows the extension to attempt to set the marker again if checkOrigin is triggered for the same origin, improving the resilience of the marker display to transient errors.