### PR TITLE
Fix: Resolve CSP and layout issues on options page

### DIFF
--- a/options.css
+++ b/options.css
@@ -2,9 +2,9 @@ html,
 body {
   color: white;
   background-color: #1b262c;
-  min-height: 10rem;
+  /* min-height: 10rem; */ /* Removed */
   max-width: 50rem;
-  overflow-y: hidden;
+  overflow-y: auto; /* Changed from hidden */
 }
 
 /* Custom Confirmation Modal Styles */
@@ -24,7 +24,7 @@ body {
 
 .modal-content {
   background-color: #fefefe;
-  margin: 15% auto; /* 15% from the top and centered */
+  margin: 5% auto; /* Changed from 15% auto */
   padding: 20px;
   border: 1px solid #888;
   width: 80%; /* Could be more specific, like 400px */
@@ -67,4 +67,8 @@ body {
 
 #cancelModalButton:hover {
   background-color: #da190b;
+}
+
+.warning-text {
+  color: #8b0000;
 }

--- a/options.html
+++ b/options.html
@@ -113,7 +113,6 @@
       <a href="#how-to-use-custom-markers">custom markers</a> for any specific
       sites you want to identify differently.
     </p>
-    <button id="reset">Clear All Extension Data (Resets Markers & Salt)</button>
     <label for="store">Storage area:</label>
     <select name="store" id="store">
       <option value="sync">Sync</option>
@@ -129,12 +128,10 @@
       <li>
         <strong>Sync:</strong> Convenient for accessing this data across devices
         where you're signed into Chrome.
-        <strong style="color: #8b0000"
-          >Warning: If your Google account is compromised, your 'salt' could
+        <strong class="warning-text">Warning: If your Google account is compromised, your 'salt' could
           also be accessed. This might allow someone to identify which websites
           correspond to your emoji markers if they also have access to your
-          bookmarks.</strong
-        >
+          bookmarks.</strong>
       </li>
       <li>
         <strong>Local:</strong> Keeps this data only on this device. This
@@ -147,6 +144,7 @@
         Useful for temporary privacy.
       </li>
     </ul>
+    <button id="reset">Clear All Extension Data (Resets Markers & Salt)</button>
     <p>
       <em
         >(Core settings like your designated OriginMarker bookmark ID and the
@@ -156,7 +154,7 @@
     </p>
 
     <!-- Custom Confirmation Modal -->
-    <div id="customConfirmModal" class="modal" style="display: none">
+    <div id="customConfirmModal" class="modal">
       <div class="modal-content">
         <p id="confirmModalText"></p>
         <div class="modal-buttons">


### PR DESCRIPTION
This commit addresses several issues on the extension's options page:

1.  **CSP Compliance:**
    - Removed inline `style="color: #8b0000"` from a `<strong>` tag, replacing it with a CSS class `.warning-text`.
    - Removed inline `style="display: none"` from the custom confirmation modal `div`, relying on the existing CSS rule `.modal { display: none; }`.

2.  **Layout Adjustments:**
    - Changed `overflow-y: hidden` to `overflow-y: auto` for `html, body` in `options.css` to allow vertical scrolling when content exceeds the embed window height.
    - Removed `min-height: 10rem` from the `body` style to allow more flexible sizing.
    - Reduced the top/bottom margin for `.modal-content` from `15%` to `5%` to prevent it from being pushed out of view in shorter windows.
    - Reordered elements: The "Storage area" label and dropdown are now positioned above the "Clear All Extension Data" button, as per your feedback. Associated descriptive text remains with the dropdown.

These changes ensure the options page adheres to Content Security Policy and improves its responsiveness and usability within embed windows of various sizes.