### PR TITLE
Refactor Prettier setup and secure workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,23 +7,9 @@ jobs:
     name: Create artifacts
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
-    - name: Format
-      run: |
-        npx prettier . --write --single-quote --no-bracket-spacing --bracket-same-line --trailing-comma none --cache --cache-location=prettier_cache
-
-    - name: Submit
-      continue-on-error: true
-      run: |
-        git config --global user.name "Prettier Bot"
-        git config --global user.email "sync@corp.google.com"
-
-        git add -A
-        git commit -m "Prettier"
-        git push origin main
-
     - name: Chrome
       run: |
         mkdir -p chrome

--- a/.github/workflows/format-on-merge.yml
+++ b/.github/workflows/format-on-merge.yml
@@ -1,0 +1,46 @@
+name: Format on Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  format:
+    name: Apply Prettier Formatting
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push changes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # The token is automatically provided by GitHub Actions.
+          # Using a token with write permissions to allow push.
+          # For pushes from the same repository, GITHUB_TOKEN has write perm by default if job has contents:write
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Run Prettier
+        run: |
+          npx prettier . --write --single-quote --no-bracket-spacing --bracket-same-line --trailing-comma none --cache --cache-location=prettier_cache
+
+      - name: Configure git
+        run: |
+          git config --global user.name "Prettier Bot"
+          git config --global user.email "prettier-bot@users.noreply.github.com"
+
+      - name: Commit and push changes
+        run: |
+          git add -A
+          # Check if there are any changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "style: apply Prettier formatting"
+            git push
+          fi

--- a/.github/workflows/format-on-merge.yml
+++ b/.github/workflows/format-on-merge.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Configure git
         run: |
           git config --global user.name "Prettier Bot"
-          git config --global user.email "prettier-bot@users.noreply.github.com"
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
This commit introduces the following changes to the GitHub Actions workflows:

1.  **Modified `build.yml`**:
    - I removed the Prettier formatting and auto-commit steps.
    - I reduced the `permissions` for the `build` job from `contents: write` to `contents: read`, enhancing security by adhering to the principle of least privilege. The job now only creates and uploads artifacts.

2.  **Created `format-on-merge.yml`**:
    - I implemented a new workflow that triggers on pushes to the `main` branch.
    - This workflow automatically applies Prettier formatting to the codebase.
    - It then commits and pushes these formatting changes.
    - This isolates the `contents: write` permission required for auto-formatting to this specific workflow, rather than granting it to the general build workflow.

3.  **Reviewed `codeql.yml`**:
    - I confirmed that the existing permissions for the CodeQL workflow are appropriate and do not require changes.

These changes improve the security of the GitHub Actions by scoping permissions more narrowly and ensure that code formatting consistency is maintained automatically upon merges to the main branch.