### PR TITLE
Refactor: Remove visually similar emojis from static.js

### DIFF
--- a/static.js
+++ b/static.js
@@ -3,7 +3,6 @@ const unknown = 'Marker';
 
 const emoji = [
   '😀', // Grinning Face
-  '😂', // Face with Tears of Joy
   '😴', // Sleeping Face
   '😷', // Face with Medical Mask
   '🤯', // Exploding Head
@@ -181,7 +180,6 @@ const emoji = [
   '🚲', // Bicycle
   '⛵', // Sailboat
   '🚢', // Ship
-  '✈️', // Airplane
   '🚁', // Helicopter
   '🚀', // Rocket
   '🛸', // Flying Saucer
@@ -234,7 +232,6 @@ const emoji = [
   '💰', // Money Bag
   '✉️', // Envelope
   '✏️', // Pencil
-  '✒️', // Black Nib
   '🖌️', // Paintbrush
   '📝', // Memo
   '📓', // Notebook
@@ -324,7 +321,6 @@ const emoji = [
   '🫧', // Bubbles
   '🪸', // Coral
   '🤔', // Thinking Face
-  '🤫', // Shushing Face
   '☀️', // Sun
   '✔️', // Check Mark
   '❌', // Cross Mark


### PR DESCRIPTION
I removed a set of emojis from the `emoji` array in `static.js` that were identified as being visually similar or easily mistaken for others. This change aims to improve the clarity and reduce potential confusion when selecting emojis.

The following emojis were removed:
- 😂 (Face with Tears of Joy)
- 🤫 (Shushing Face)
- ✈️ (Airplane)
- ✒️ (Black Nib)

A review was conducted after the removal to ensure no essential emojis were lost and that the remaining list is diverse and distinct.