### PR TITLE
Refactor: Remove lookalike emoji from static.js

### DIFF
--- a/static.js
+++ b/static.js
@@ -31,7 +31,6 @@ const emoji = [
   '🦷', // Tooth
   '👮', // Police Officer
   '🤴', // Prince
-  '👸', // Princess
   '🎅', // Santa Claus
   '🦸', // Superhero
   '🧟', // Zombie
@@ -122,7 +121,6 @@ const emoji = [
   '🥐', // Croissant
   '🥨', // Pretzel
   '🧀', // Cheese Wedge
-  '🍔', // Hamburger
   '🍕', // Pizza
   '🥚', // Egg
   '🍿', // Popcorn
@@ -187,7 +185,6 @@ const emoji = [
   '🎄', // Christmas Tree
   '🎉', // Party Popper
   '🏆', // Trophy
-  '🥇', // 1st Place Medal
   '⚽', // Soccer Ball
   '🏀', // Basketball
   '🏈', // American Football


### PR DESCRIPTION
Removed emoji that could be easily mistaken for others:
- Princess (similar to Prince)
- Hamburger (can be confused with Hot Dog)
- 1st Place Medal (similar to Trophy)

This change aims to improve clarity and reduce potential confusion when selecting emoji. No new emoji were added at this time to maintain a concise list.