### PR TITLE
Fix: Harden GitHub Actions in format-on-merge.yml

### DIFF
--- a/.github/workflows/format-on-merge.yml
+++ b/.github/workflows/format-on-merge.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '18'
 


### PR DESCRIPTION
Pinned actions/setup-node to a specific commit SHA (49933ea5288caeca8642d1e84afbd3f7d6820020) to improve supply chain security.

The actions/checkout action was already pinned to a specific SHA.