### PR TITLE
docs: Update security.md to reflect verified action pinning

### DIFF
--- a/security.md
+++ b/security.md
@@ -175,7 +175,7 @@ This section details potential attack vectors relevant to OriginMarker's code, l
     - Chrome Web Store signing: Once packaged and uploaded, the extension is signed by the Chrome Web Store, which helps ensure that the version installed by users hasn't been tampered with post-publication.
   - **GitHub Actions:**
     - Regular review of workflow permissions and any third-party actions used.
-    - Pinning actions to specific commit SHAs rather than branches or tags to prevent unexpected updates from introducing vulnerabilities.
+- Pinning actions to specific commit SHAs rather than branches or tags to prevent unexpected updates from introducing vulnerabilities. (This is confirmed to be in place for the `actions/checkout` and `actions/setup-node` actions within the `format-on-merge.yml` workflow.)
     - Implementing strong branch protection rules for `main`, requiring reviews before merging, even for workflow-generated commits if feasible.
 
 ### 4.8. Robustness Against Malformed Data from `static.js`


### PR DESCRIPTION
I've updated section 4.7 of `security.md` to confirm that GitHub Actions (`actions/checkout` and `actions/setup-node`) within the `format-on-merge.yml` workflow are pinned to specific commit SHAs, enhancing clarity on existing supply chain security measures.