### PR TITLE
Refactor: Enhance DoS state user feedback and verify init robustness.

### DIFF
--- a/background.js
+++ b/background.js
@@ -520,6 +520,8 @@ function enterDosCooldownMode() {
 
   currentDosState = DOS_STATE_COOLDOWN;
   setMarker(null); // Set to generic/unknown marker
+  chrome.action.setBadgeText({text: 'BUSY'});
+  chrome.action.setBadgeBackgroundColor({color: '#FFA500'}); // Orange
 
   // Clear any existing timer to ensure only one recovery path is active
   if (dosCooldownTimer) {
@@ -545,6 +547,7 @@ function checkDosRecovery() {
       'OriginMarker: Event rate normal. Recovering from DoS cooldown.'
     );
     currentDosState = DOS_STATE_NORMAL;
+    chrome.action.setBadgeText({text: ''}); // Clear the badge
     // Attempt to set the correct marker for the current tab immediately
     checkOrigin();
   }


### PR DESCRIPTION
This change introduces user-facing feedback for the DoS (Denial of Service) protection mechanism by utilizing the extension's action badge. When the DoS cooldown mode is activated due to high event frequency, the badge will now display "BUSY" with an orange background. The badge is cleared when the event rate returns to normal and the extension resumes normal operation.

Additionally, I analyzed the `onPlaceholder` and `initBookmark` functions. My analysis confirmed that the existing initialization logic is robust in handling scenarios where `setMode` might consistently fail (e.g., due to persistent storage errors). The extension correctly remains in a "pending setup" state without entering harmful loops and manages task abortion and re-initialization appropriately. No code changes were needed for this aspect.